### PR TITLE
add checks to permissions to change page URL

### DIFF
--- a/snippets/main.php
+++ b/snippets/main.php
@@ -6,7 +6,9 @@
 		<div class="seo-wrap seo-wrap-title">
 			<div class="seo-view seo-view-title"></div>
 		</div>
-		<a class="seo-wrap seo-wrap-url" data-modal="" href="<?php echo $controller['url']['edit']; ?>">
+		<a class="seo-wrap seo-wrap-url"<?php 
+		   // test whether Page allows changing URL, and whether User has permission to change it
+		   if($page->ui()->url() && site()->user()->can('panel.page.url')): ?> data-modal="" href="<?php echo $controller['url']['edit']; ?>"<?php endif ?>>
 			<div class="seo-view seo-view-url"><?php echo $controller['url']['preview']; ?></div>
 		</a>
 		<div class="seo-wrap seo-wrap-description">


### PR DESCRIPTION
If the currently logged in user does not have permission to change the URL of the current page, or the page itself has its 'change url' permission set to 'false' in the blueprint, and the user clicks on the page URL link inside the SEO field, it causes a Panel error.  This change will simply check whether these permissions are present or not. If they aren't it will change the attributes of the URL link inside the SEO field, so that clicking on it will do nothing - and will no longer cause any errors.